### PR TITLE
Fix autoload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A CUIT/CUIL validator for PHP for use in Argentina.
 It checks the CUITs length, type and checksum number. Accepts both hyphenated and only-numbers CUITs.
 
 ```php
-require_once __DIR__ . "vendor/autoload.php";
+require_once __DIR__ . "/vendor/autoload.php";
 
 $cuit = new \Cuit\Cuit("20-12345678-9");
 


### PR DESCRIPTION
## Summary
- correct autoload path in README example

## Testing
- `./vendor/bin/phpunit --verbose tests/CuitTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f97ed4e08832fafab7ef05411e069